### PR TITLE
Bill status feedback

### DIFF
--- a/scripts/components/App.js
+++ b/scripts/components/App.js
@@ -89,7 +89,7 @@ BillCreationForm.contextTypes = {
   router: React.PropTypes.func
 };
 
-export class Bills extends React.Component {
+export class BillList extends React.Component {
 
   static get defaultProps() {
     return {items: []};
@@ -123,7 +123,7 @@ export class Bills extends React.Component {
 }
 
 
-export class BillList extends React.Component {
+export class BillView extends React.Component {
 
   constructor(props) {
     super(props);
@@ -146,7 +146,7 @@ export class BillList extends React.Component {
     var disabled = this.state.busy ? "disabled" : "";
     return (
       <div className={disabled}>
-        <Bills items={this.state.items}/>
+        <BillList items={this.state.items}/>
         <div className="error">{this.state.error}</div>
         <Link to="new-bill">HERE</Link>
       </div>

--- a/scripts/components/App.js
+++ b/scripts/components/App.js
@@ -97,7 +97,7 @@ export class BillList extends React.Component {
 
   render() {
     return (
-      <div id="billList">
+      <div id="bill-list">
           <table className="table table-striped">
               <thead>
                   <tr><th>Who paid?</th><th>What?</th><th>How much?</th><th>For whom?</th><th>Date</th></tr>
@@ -106,13 +106,14 @@ export class BillList extends React.Component {
               {
                 this.props.items.map((item, i) => {
                   return (
-                    <tr key={i}>
+                    <tr key={i} className="bill" data-status={item._status}>
                         <td>{item.payer}</td>
                         <td>{item.description}</td>
                         <td>{item.amount}</td>
                         <td>{item.owers}</td>
                         <td>{item.date}</td>
-                    </tr>);
+                    </tr>
+                  );
                 })
               }
               </tbody>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -7,7 +7,7 @@ require("./style/app.less")
 import "babel/polyfill";
 import btoa from "btoa";
 import React from "react";
-import { BillList, BillCreationForm } from "./components/App";
+import { BillView, BillCreationForm } from "./components/App";
 import { Store } from "./store";
 import Kinto from "kinto";
 import Router, { Route, DefaultRoute }  from "react-router";
@@ -36,11 +36,11 @@ store.collection.db.dbname = userpass64 + store.collection.db.dbname;
 // XXX redirect by default to the bill list.
 var routes = (
     <Route>
-        <DefaultRoute handler={BillList}/>
+        <DefaultRoute handler={BillView}/>
         <Route name="new-bill"
                handler={BillCreationForm} />
        <Route name="bill-list"
-              handler={BillList} />
+              handler={BillView} />
     </Route>
 );
 

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -16,7 +16,7 @@ export class Store extends EventEmitter {
   }
 
   onError(error) {
-      console.log(error);
+    console.log(error);
     this.emit("error", error);
   }
 

--- a/scripts/style/app.less
+++ b/scripts/style/app.less
@@ -1,3 +1,7 @@
 #bill-creation-form{
     margin: 1em;
 }
+
+#bill-list .bill[data-status=created] {
+	font-style: italic;
+}


### PR DESCRIPTION
Set the bill in italic when they have not been synced yet (better UI should be investigated later).
Should be reviewed. This leverages the `_status` property of the bills. I am not certain about the meaning of `_` here.
Usually underscore means that we should not read or touch it at all though I have seen some cases where it meant that it has special meaning but that you can still use it.
If we are not supposed to use it, it means that `kinto.js` does not provide any (official) info about the status of the record (synced or not in particular), which is sad.
It also means that we will need to register it manually... Which may not be that trivial.
We can add our own `status` on the bill records. However I am not sure when to set it as `synced` then. We can do it before the sync, meaning that it will be temporary set to sync even if it is not yet and may not be at all, or after the sync, meaning that it will be registered as "unsynced" on the server (a bit odd though it doesn't really matter for the server).
Another solution would be to put this sync attribute in a separate table so that is not synced at all (it is local stuff anyway).
This actually makes me think that it may be nice to be able to specify attributes that should not be shared with the server with `kinto.js`.
